### PR TITLE
feat: adds a11y for ContentType & Responses region

### DIFF
--- a/src/core/components/content-type.jsx
+++ b/src/core/components/content-type.jsx
@@ -8,7 +8,9 @@ const noop = ()=>{}
 export default class ContentType extends React.Component {
 
   static propTypes = {
+    ariaControls: PropTypes.string,
     contentTypes: PropTypes.oneOfType([ImPropTypes.list, ImPropTypes.set, ImPropTypes.seq]),
+    controlId: PropTypes.string,
     value: PropTypes.string,
     onChange: PropTypes.func,
     className: PropTypes.string,
@@ -41,14 +43,14 @@ export default class ContentType extends React.Component {
   onChangeWrapper = e => this.props.onChange(e.target.value)
 
   render() {
-    let { contentTypes, className, value, ariaLabel } = this.props
+    let { ariaControls, contentTypes, className, controlId, value, ariaLabel } = this.props
 
     if ( !contentTypes || !contentTypes.size )
       return null
 
     return (
       <div className={ "content-type-wrapper " + ( className || "" ) }>
-        <select className="content-type" aria-label={ariaLabel} value={value || ""} onChange={this.onChangeWrapper} >
+        <select aria-controls={ariaControls} aria-label={ariaLabel} className="content-type" id={controlId} value={value || ""} onChange={this.onChangeWrapper} >
           { contentTypes.map( (val) => {
             return <option key={ val } value={ val }>{ val }</option>
           }).toArray()}

--- a/src/core/components/responses.jsx
+++ b/src/core/components/responses.jsx
@@ -3,6 +3,7 @@ import { fromJS, Iterable } from "immutable"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
 import { defaultStatusCode, getAcceptControllingResponse } from "core/utils"
+import createHtmlReadyId from "../../helpers/create-html-ready-id"
 
 export default class Responses extends React.Component {
   static propTypes = {
@@ -86,15 +87,20 @@ export default class Responses extends React.Component {
     const acceptControllingResponse = isSpecOAS3 ?
       getAcceptControllingResponse(responses) : null
 
+    const regionId = createHtmlReadyId(`${method}${path}_responses`)
+    const controlId = `${regionId}_select`
+
     return (
       <div className="responses-wrapper">
         <div className="opblock-section-header">
           <h4>Responses</h4>
-            { specSelectors.isOAS3() ? null : <label>
+            { specSelectors.isOAS3() ? null : <label htmlFor={controlId}>
               <span>Response content type</span>
               <ContentType value={producesValue}
                          onChange={this.onChangeProducesWrapper}
                          contentTypes={produces}
+                         controlId={controlId}
+                         ariaControls={regionId}
                          className="execute-content-type"
                          ariaLabel="Response content type" />
                      </label> }
@@ -115,7 +121,7 @@ export default class Responses extends React.Component {
 
           }
 
-          <table className="responses-table">
+          <table aria-live="polite" className="responses-table" id={regionId} role="region">
             <thead>
               <tr className="responses-header">
                 <td className="col_header response-col_status">Code</td>

--- a/src/helpers/create-html-ready-id.js
+++ b/src/helpers/create-html-ready-id.js
@@ -1,0 +1,10 @@
+/**
+ * Replace invalid characters from a string to create an html-ready ID
+ *
+ * @param {string} id A string that may contain invalid characters for the HTML ID attribute
+ * @param {string} [replacement=_] The string to replace invalid characters with; "_" by default
+ * @return {string} Information about the parameter schema
+ */
+export default function createHtmlReadyId(id, replacement = "_") {
+  return id.replace(/[^\w-]/g, replacement)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This ticket supports [API-163](https://vajira.max.gov/browse/API-163). After talking @brentschneider we determined that a button for executing changes wasn't necessary as the focus did not change from the select dropdown. Instead we've added accessibility upgrades that announce the changed content upon making a selection.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
Tested using VoiceOver for Mac (native software)
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [X] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [X] are not breaking changes.

### Documentation
- [X] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [X] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
