### PR TITLE
Fix optag heading heirarchy

### DIFF
--- a/src/core/components/operation-tag.jsx
+++ b/src/core/components/operation-tag.jsx
@@ -70,7 +70,7 @@ export default class OperationTag extends React.Component {
     return (
       <div className={showTag ? "opblock-tag-section is-open" : "opblock-tag-section"} >
 
-        <h4
+        <h3
           onClick={() => layoutActions.show(isShownKey, !showTag)}
           className={!tagDescription ? "opblock-tag no-desc" : "opblock-tag" }
           id={isShownKey.map(v => escapeDeepLinkPath(v)).join("-")}
@@ -114,7 +114,7 @@ export default class OperationTag extends React.Component {
                 <use href={showTag ? "#large-arrow-up" : "#large-arrow-down"} xlinkHref={showTag ? "#large-arrow-up" : "#large-arrow-down"} />
               </svg>
             </button>
-        </h4>
+        </h3>
 
         <Collapse isOpened={showTag}>
           {children}

--- a/test/unit/components/operation-tag.jsx
+++ b/test/unit/components/operation-tag.jsx
@@ -3,7 +3,6 @@ import { shallow } from "enzyme"
 import OperationTag from "components/operation-tag"
 import Im from "immutable"
 import { Link } from "components/layout-utils"
-import { expect } from "@jest/globals"
 
 describe("<OperationTag/>", function(){
   it("render externalDocs URL for swagger v2", function(){

--- a/test/unit/components/operation-tag.jsx
+++ b/test/unit/components/operation-tag.jsx
@@ -3,6 +3,7 @@ import { shallow } from "enzyme"
 import OperationTag from "components/operation-tag"
 import Im from "immutable"
 import { Link } from "components/layout-utils"
+import { expect } from "@jest/globals"
 
 describe("<OperationTag/>", function(){
   it("render externalDocs URL for swagger v2", function(){
@@ -44,6 +45,7 @@ describe("<OperationTag/>", function(){
 
     const opblockTag = wrapper.find(".opblock-tag")
     expect(opblockTag.length).toEqual(1)
+    expect(opblockTag.getNode().type).toEqual("h3")
 
     const renderedLink = wrapper.find("Link")
     expect(renderedLink.length).toEqual(1)


### PR DESCRIPTION
Updates the heading for the operation tag from an h4 to an h3.

### Description
Currently on page the top of the Swagger UI component is an h2 and then headings down the rest of the page are h4's. While there should be, there is no progression through heading levels from h2 through to the h4's on page. Currently it goes h2 > h4 > h4 and this PR will better structure the component with h2 > h3 > h4.

### Motivation and Context
This addresses an accessibility concern we noticed as heading levels help those using assistive technology to determine page hierarchy better.

### How Has This Been Tested?
First: `npm run test:unit-jest -- test/unit/components/operation-tag.jsx`
After completed ran a full: `npm run test`
Also visually compared the pages on petstore demo with h3 and h4 tags and there was no visual changes by this change.


### Screenshots (if appropriate):
Images showing the h4 > h4 hierarchy previously present
![image](https://user-images.githubusercontent.com/304798/116304261-5e960d80-a770-11eb-8e3a-1ad30e248eda.png)
![image](https://user-images.githubusercontent.com/304798/116304360-7c637280-a770-11eb-9382-97250391f3c1.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
